### PR TITLE
Sync llvm_install.sh with upstream SVF LLVM 21.1.0

### DIFF
--- a/llvm_install.sh
+++ b/llvm_install.sh
@@ -2,10 +2,10 @@
 SVFHOME=$(pwd)
 sysOS=`uname -s`
 arch=`uname -m`
-MajorLLVMVer=18
+MajorLLVMVer=21
 LLVMVer=${MajorLLVMVer}.1.0
-UbuntuLLVM_RTTI="https://github.com/SVF-tools/SVF/releases/download/SVF-3.2/llvm-${LLVMVer}-ubuntu20-rtti-x86-64.tar.gz"
-UbuntuArmLLVM_RTTI="https://github.com/SVF-tools/SVF/releases/download/SVF-3.2/llvm-${LLVMVer}-ubuntu22-rtti-aarch64.tar.gz"
+UbuntuLLVM_RTTI="https://github.com/bjjwwang/SVF-LLVM/releases/download/${LLVMVer}/llvm-${LLVMVer}-ubuntu22-rtti-x86-64.tar.gz"
+UbuntuArmLLVM_RTTI="https://github.com/bjjwwang/SVF-LLVM/releases/download/${LLVMVer}/llvm-${LLVMVer}-ubuntu22-rtti-aarch64.tar.gz"
 
 UbuntuZ3Arm="https://github.com/SVF-tools/SVF-npm/raw/prebuilt-libs/z3-4.8.7-aarch64-ubuntu.zip"
 UbuntuZ3="https://github.com/Z3Prover/z3/releases/download/z3-4.8.8/z3-4.8.8-x64-ubuntu-16.04.zip"


### PR DESCRIPTION
Bumped MajorLLVMVer 18 -> 21 and pointed UbuntuLLVM_RTTI / UbuntuArmLLVM_RTTI at bjjwwang/SVF-LLVM/releases/download/${LLVMVer}/, matching upstream SVF/build.sh after Port-SVF-to-LLVM-21 (#1815). The x86 tarball also moved from ubuntu20-rtti to ubuntu22-rtti to match the new release artifacts.